### PR TITLE
fix 0.3.0 release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,12 +12,14 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 2
+  number: 3
 
 requirements:
   host:
     - python >=3.6
     - pip
+  run:
+    - python >=3.6
 
 test:
   imports:


### PR DESCRIPTION
This is wrong:

```
pypushflow 0.3.0 py310ha770c72_2
--------------------------------
file name   : pypushflow-0.3.0-py310ha770c72_2.tar.bz2
name        : pypushflow
version     : 0.3.0
build       : py310ha770c72_2
build number: 2
size        : 5 KB
license     : MIT
subdir      : linux-64
url         : https://conda.anaconda.org/conda-forge/linux-64/pypushflow-0.3.0-py310ha770c72_2.tar.bz2
md5         : 96a9eb6a9a0dce71e4902bd5a174fdd7
timestamp   : 2022-08-31 11:54:26 UTC
dependencies: 
  - python >=3.10,<3.11.0a0
  - python_abi 3.10.* *_cp310
```

This is correct:

```
pypushflow 0.3.0 pyhd8ed1ab_0
-----------------------------
file name   : pypushflow-0.3.0-pyhd8ed1ab_0.tar.bz2
name        : pypushflow
version     : 0.3.0
build       : pyhd8ed1ab_0
build number: 0
size        : 25 KB
license     : MIT
subdir      : noarch
url         : https://conda.anaconda.org/conda-forge/noarch/pypushflow-0.3.0-pyhd8ed1ab_0.tar.bz2
md5         : 3b912f850ee7bb66b92fbc96a9874258
timestamp   : 2022-08-30 14:57:25 UTC
dependencies: 
  - python >=3.6
```
